### PR TITLE
nsqd instances should be contacted at their broadcast_address, if specified

### DIFF
--- a/NSQnet/NSQ.cs
+++ b/NSQnet/NSQ.cs
@@ -90,14 +90,16 @@ namespace NSQnet
                 {
                     foreach (var producer in _lookupClient.ProducersForTopic(topic))
                     {
-                        if (!_mappedSubscribers.ContainsKey(producer.Hostname.ToLower()))
+                        var addr = (producer.Broadcast_Address ?? producer.Hostname).ToLower();
+
+                        if (!_mappedSubscribers.ContainsKey(addr))
                         {
-                            var sub = _getSubscriber(producer.Hostname.ToLower(), producer.Hostname.ToLower(), producer.Hostname, (int)producer.TCP_Port, topic);
+                            var sub = _getSubscriber(addr, addr, addr, (int) producer.TCP_Port, topic);
                             _mappedSubscribers.AddOrUpdate(sub.LongIdentifier, sub, (long_id, oldSub) => sub);
                         }
-                        else if (!_mappedSubscribers[producer.Hostname.ToLower()].IsSubscribed(topic, topic))
+                        else if (!_mappedSubscribers[addr].IsSubscribed(topic, topic))
                         {
-                            _mappedSubscribers[producer.Hostname.ToLower()].Subscribe(topic, topic);
+                            _mappedSubscribers[addr].Subscribe(topic, topic);
                         }
                     }
                 }


### PR DESCRIPTION
The `--broadcast_address` option allows nsqd instances to listen on a specific interface that may differ from the default interface captured by the `hostname`.  For example, (1) a server may have multiple NICs, or (2) the hostname may not be resolvable to an IP address because DNS is not set up.

In my case, the nsqd hostname of my laptop was not resolvable to an IP address from the Windows VM running the NSQNet.CLI example code even though both machines are on the same 192.168.1.0 subnet because I don't have DNS setup or a HOSTS file entry.   Instead, patching the code to honor the broadcast_address option allows the NSQNet.CLI client to discover and connect to the nsqd instance as expected.
