### PR TITLE
use UTF8 to replace Default and remove ASCII

### DIFF
--- a/NSQnet/NSQProtocol.cs
+++ b/NSQnet/NSQProtocol.cs
@@ -371,13 +371,12 @@ namespace NSQnet
 
         private static Byte[] ConvertToAscii(String unicode)
         {
-            var bytes = System.Text.Encoding.Default.GetBytes(unicode);
-            return System.Text.Encoding.Convert(System.Text.Encoding.Default, System.Text.Encoding.ASCII, bytes);
+            return Encoding.UTF8.GetBytes(unicode);
         }
 
         private static String ConvertFromAscii(Byte[] bytes)
         {
-            return System.Text.Encoding.Default.GetString(System.Text.Encoding.Convert(System.Text.Encoding.ASCII, System.Text.Encoding.Default, bytes));
+            return Encoding.UTF8.GetString(bytes);
         }
 
         private static Byte[] PackMessage(String text)


### PR DESCRIPTION
my server default encoding is "GB2312", but nsq message encoding is "UTF8".
if convert UTF8 to GB2312 and then convert them to ASCII bytes,  we will lost all informat except ASCII characters.
BTW,  in .net we write code use UTF8 encoding as default.